### PR TITLE
Further trivially-relocatable support

### DIFF
--- a/all_in_one.hpp
+++ b/all_in_one.hpp
@@ -1628,6 +1628,7 @@ constexpr T* launder(T* p) noexcept
 #ifndef STDX_ERROR_HPP
 #define STDX_ERROR_HPP
 
+#include <exception>
 #include <stdexcept>
 #include <system_error>
 #include <memory>

--- a/all_in_one.hpp
+++ b/all_in_one.hpp
@@ -174,22 +174,25 @@ template <class T>
 using is_trivially_move_constructible = std::is_trivially_move_constructible<T>;
 #else
 template <class T>
-struct is_trivially_move_constructible : is_trivially_copyable<T>
-{ };
+using is_trivially_move_constructible = is_trivially_copyable<T>;
 #endif
 
+#if defined(__cpp_lib_trivially_relocatable)
+using std::is_trivially_relocatable;
+#elif defined(__has_builtin)
+	#if __has_builtin(__is_trivially_relocatable)
+	template <class T>
+	struct is_trivially_relocatable : std::bool_constant<__is_trivially_relocatable(T)> { };
+	#define STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
+	#else
+	template <class T>
+	struct is_trivially_relocatable : is_trivially_copyable<T> { };
+	#define STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
+	#endif
+#else
 template <class T>
-struct is_trivially_relocatable
-	:
-	bool_constant<
-		is_trivially_move_constructible<T>::value
-		&& std::is_trivially_destructible<T>::value
-	>
-{ };
-
-#if defined(STDX_VARIABLE_TEMPLATES)
-template <class T>
-inline constexpr bool is_trivially_relocatable_v = is_trivially_relocatable<T>::value;
+struct is_trivially_relocatable : is_trivially_copyable<T> { };
+#define STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
 #endif
 
 #if __cplusplus >= 201703L
@@ -781,7 +784,7 @@ template <
 	class Deleter,
 	class Pointer
 >
-class intrusive_ptr
+class STDX_TRIVIALLY_RELOCATABLE intrusive_ptr
 	: 
 	public detail::intrusive_ptr_base<
 		T, 
@@ -1129,11 +1132,11 @@ void swap(intrusive_ptr<T, G, D, P>& lhs, intrusive_ptr<T, G, D, P>& rhs) noexce
 	lhs.swap(rhs);
 }
 
-// -------- specialization for is_trivially_relocatable
-//
+#ifdef STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
 template <class Y, class G, class D, class P>
 struct is_trivially_relocatable<intrusive_ptr<Y,G,D,P>> : std::true_type
 { };
+#endif
 	
 } // end namespace stdx
 
@@ -2713,9 +2716,11 @@ namespace detail {
 
 } // end namespace detail
 
+#ifdef STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
 template <>
 struct is_trivially_relocatable<detail::exception_ptr_wrapper> : std::true_type
 { };
+#endif
 
 // Error domain mapping to std::exception_ptr
 //

--- a/include/error.hpp
+++ b/include/error.hpp
@@ -1,6 +1,7 @@
 #ifndef STDX_ERROR_HPP
 #define STDX_ERROR_HPP
 
+#include <exception>
 #include <stdexcept>
 #include <system_error>
 #include <memory>

--- a/include/error.hpp
+++ b/include/error.hpp
@@ -1101,9 +1101,11 @@ namespace detail {
 
 } // end namespace detail
 
+#ifdef STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
 template <>
 struct is_trivially_relocatable<detail::exception_ptr_wrapper> : std::true_type
 { };
+#endif
 
 // Error domain mapping to std::exception_ptr
 //

--- a/include/intrusive_ptr.hpp
+++ b/include/intrusive_ptr.hpp
@@ -418,7 +418,7 @@ template <
 	class Deleter,
 	class Pointer
 >
-class intrusive_ptr
+class STDX_TRIVIALLY_RELOCATABLE intrusive_ptr
 	: 
 	public detail::intrusive_ptr_base<
 		T, 
@@ -766,11 +766,13 @@ void swap(intrusive_ptr<T, G, D, P>& lhs, intrusive_ptr<T, G, D, P>& rhs) noexce
 	lhs.swap(rhs);
 }
 
+#ifdef STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
 // -------- specialization for is_trivially_relocatable
 //
 template <class Y, class G, class D, class P>
 struct is_trivially_relocatable<intrusive_ptr<Y,G,D,P>> : std::true_type
 { };
+#endif
 	
 } // end namespace stdx
 

--- a/include/type_traits.hpp
+++ b/include/type_traits.hpp
@@ -107,22 +107,25 @@ template <class T>
 using is_trivially_move_constructible = std::is_trivially_move_constructible<T>;
 #else
 template <class T>
-struct is_trivially_move_constructible : is_trivially_copyable<T>
-{ };
+using is_trivially_move_constructible = is_trivially_copyable<T>;
 #endif
 
+#if defined(__cpp_lib_trivially_relocatable)
+using std::is_trivially_relocatable;
+#elif defined(__has_builtin)
+	#if __has_builtin(__is_trivially_relocatable)
+	template <class T>
+	struct is_trivially_relocatable : std::bool_constant<__is_trivially_relocatable(T)> { };
+	#define STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
+	#else
+	template <class T>
+	struct is_trivially_relocatable : is_trivially_copyable<T> { };
+	#define STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
+	#endif
+#else
 template <class T>
-struct is_trivially_relocatable
-	:
-	bool_constant<
-		is_trivially_move_constructible<T>::value
-		&& std::is_trivially_destructible<T>::value
-	>
-{ };
-
-#if defined(STDX_VARIABLE_TEMPLATES)
-template <class T>
-inline constexpr bool is_trivially_relocatable_v = is_trivially_relocatable<T>::value;
+struct is_trivially_relocatable : is_trivially_copyable<T> { };
+#define STDX_MUST_SPECIALIZE_IS_TRIVIALLY_RELOCATABLE
 #endif
 
 #if __cplusplus >= 201703L


### PR DESCRIPTION
This addresses my late-breaking "oops" comment from #1.
I strongly recommend testing "error.cpp" in all modes with GCC and/or your compiler of choice, before merging this one. :)

    For example, if the P1144-enabled library (or even Clang trunk with
    libc++'s `_LIBCPP_ABI_ENABLE_UNIQUE_PTR_TRIVIAL_ABI` defined) reports
    that `unique_ptr` is trivially relocatable, then we should use that.
    
    A type which is trivially move-constructible and trivially destructible
    but NOT trivially move-assignable, is not considered trivially relocatable
    by P1144. `stdx::error` could actually take its trivial codepaths for
    such a type, but if anyone actually used such a type with `stdx::error`
    today, then when they upgraded to a P1144-enabled compiler, they'd start
    getting errors because their type was no longer considered trivially
    relocatable. It seems more futureproof to be conservative in the
    "zero compiler/library support" codepath, and accept only types that
    are 100% trivially copyable. (Move-only types can indeed be trivially
    copyable, and I'm not aware of any type that is known to the compiler
    to be trivially constructible and destructible without also being
    trivially assignable, so I claim this is fine.)
    
    "test.cpp" now compiles with Clang trunk and also my Clang P1144 fork,
    in C++14, 17, 20, and 23.

